### PR TITLE
feat(redot-parse): include comments in abstract syntax tree

### DIFF
--- a/packages/redot-parse/dot.pegjs
+++ b/packages/redot-parse/dot.pegjs
@@ -5,10 +5,10 @@
  */
 
 start
-  = graph:graph+ {
+  = children:(graph / COMMENT)+ {
     return {
       type: 'root',
-      children: graph,
+      children: children,
       data: {},
       position: location()
     }
@@ -47,6 +47,7 @@ stmt
   / subgraph
   / node_stmt
   / ID '=' ID
+  / COMMENT
 
 attr_stmt
   = target:('graph'i/'node'i/'edge'i) attr:attr_list {
@@ -288,17 +289,38 @@ COMMENT "COMMENT"
  = (BLOCK_COMMENT / C_COMMENT / MACRO_COMMENT)
 
 BLOCK_COMMENT "BLOCK_COMMENT"
-  = '/*' v:(!'*/' v:. {return v;})* '*/' { return v.join('') }
+  = '/*' v:(!'*/' v:. {return v;})* '*/' {
+    return {
+      type: 'commentBlock',
+      value: v.join(''),
+      data: {},
+      position: location()
+    }
+  }
 
 C_COMMENT "C_COMMENT"
-  = '//' v:(![\n] v:. { return v; })* [\n]? { return v.join(''); }
+  = '//' v:(![\n] v:. { return v; })* [\n]? {
+    return {
+      type: 'commentInline',
+      value: v.join(''),
+      data: {},
+      position: location()
+    }
+  }
 
 MACRO_COMMENT "MACRO_COMMENT"
-  = '#' v:(![\n] v:. { return v; })* [\n]? { return v.join(''); }
+  = '#' v:(![\n] v:. { return v; })* [\n]? {
+    return {
+      type: 'commentMacro',
+      value: v.join(''),
+      data: {},
+      position: location()
+    }
+  }
 
 
 _ "WHITESPACE"
-  = (WHITESPACE / COMMENT)*
+  = WHITESPACE*
 
 NEWLINE
   = [\n\r]+

--- a/packages/redot-stringify/redot-stringify.js
+++ b/packages/redot-stringify/redot-stringify.js
@@ -85,6 +85,9 @@ function graph(node) {
   result += " {\n";
 
   result += [
+    utilProcessChildType(node, commentMacro),
+    utilProcessChildType(node, commentBlock),
+    utilProcessChildType(node, commentInline),
     utilProcessChildType(node, attribute),
     utilProcessChildType(node, attributeStatement),
     utilProcessChildType(node, nodeStatement),
@@ -114,10 +117,30 @@ function subgraph(node) {
   return graph(node);
 }
 
+function commentBlock(node) {
+  return "/*" + node.value + "*/";
+}
+
+function commentInline(node) {
+  return "//" + node.value;
+}
+
+function commentMacro(node) {
+  return "#" + node.value;
+}
+
 function root(node) {
-  return (
-    utilProcessChildType(node, digraph) + utilProcessChildType(node, graph)
-  );
+  return [
+    utilProcessChildType(node, commentMacro),
+    utilProcessChildType(node, commentBlock),
+    utilProcessChildType(node, commentInline),
+    utilProcessChildType(node, digraph),
+    utilProcessChildType(node, graph)
+  ]
+    .filter(function(value) {
+      return value !== "";
+    })
+    .join("\n");
 }
 
 var compile = function compile(doc) {


### PR DESCRIPTION
Comments have three types commentBlock, commentInline, and commentMacro.

resolves #7