### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Build and test
+on: [push, pull_request]
+jobs:
+  build-and-test:
+    name: '${{ matrix.platform }}: Node.js ${{ matrix.nodejs-version }}'
+    strategy:
+      matrix:
+        nodejs-version: [6, 8, 10]
+        platform: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Set up Node.js
+        uses: actions/setup-node@master
+        with:
+          version: ${{ matrix.nodejs-version }}
+      - name: Build and test
+        run: |
+          npm install
+          npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build and test
+name: CI
 on: [push, pull_request]
 jobs:
   build-and-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ jobs:
     name: '${{ matrix.platform }}: node.js ${{ matrix.nodejs-version }}'
     strategy:
       matrix:
-        nodejs-version: [6, 8, 10]
         platform: [ubuntu-latest, windows-latest, macos-latest]
+        nodejs-version: [6, 8, 10]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 jobs:
   build-and-test:
     name: '${{ matrix.platform }}: node.js ${{ matrix.nodejs-version }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build and test
 on: [push, pull_request]
 jobs:
   build-and-test:
-    name: '${{ matrix.platform }}: Node.js ${{ matrix.nodejs-version }}'
+    name: '${{ matrix.platform }}: node.js ${{ matrix.nodejs-version }}'
     strategy:
       matrix:
         nodejs-version: [6, 8, 10]


### PR DESCRIPTION
This pull request implements CI via GitHub Actions. Here is how the setup works:

- The workflow is triggered on `push` and `pull_request` events.
- It sets up NodeJS for Linux, Windows, and macOS.
- It runs Node.js 6, 8, and 10 across those three platforms.

There is an optional status badge that you can add to the Readme if you’d like. I’m more than happy to add the commit if you are interested.